### PR TITLE
feat: postgres adapter

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,19 @@ jobs:
         image: mongo:6
         ports:
         - 27017:27017
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: mydatabase
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - name: Checkout git repo

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -1,0 +1,1 @@
+# Mallard PostgreSQL Store (next.jdbc)

--- a/packages/postgres/deps.edn
+++ b/packages/postgres/deps.edn
@@ -1,0 +1,15 @@
+{:kmono/package {:name mallard-postgres-store}
+
+ :deps {com.kepler16/mallard {:local/root "../mallard"}
+
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.1002"}
+
+        metosin/malli {:mvn/version "0.16.3"}
+        tick/tick {:mvn/version "0.7.5"}}
+
+ :aliases {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
+                               nubank/matcher-combinators {:mvn/version "3.9.1"}
+                               org.postgresql/postgresql {:mvn/version "42.7.5"}
+                               hikari-cp/hikari-cp {:mvn/version "3.2.0"}}
+                  :extra-paths ["test"]
+                  :main-opts ["-m" "kaocha.runner" "-c" "../../tests.edn"]}}}

--- a/packages/postgres/src/k16/mallard/store/postgres.clj
+++ b/packages/postgres/src/k16/mallard/store/postgres.clj
@@ -1,0 +1,98 @@
+(ns k16.mallard.store.postgres
+  (:require
+   [k16.mallard.store :as mallard.store]
+   [malli.core :as m]
+   [malli.error :as me]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as rs]
+   [next.jdbc.date-time]
+   [tick.core :as t]))
+
+(set! *warn-on-reflection* true)
+
+(defonce LOCK_ID (hash "mallard_postgres_lock"))
+
+(def ^:private ^:sql log-table-schema
+  "CREATE TABLE IF NOT EXISTS %s (
+     id TEXT NOT NULL,
+     direction TEXT NOT NULL,
+     started_at TIMESTAMP NOT NULL,
+     finished_at TIMESTAMP NOT NULL
+   )")
+
+(defn- row->entry
+  [{:keys [id direction started_at finished_at]}]
+  {:id id
+   :direction (keyword direction)
+   :started_at (t/instant started_at)
+   :finished_at (t/instant finished_at)})
+
+(defn- entry->row
+  [{:keys [id direction started_at finished_at]}]
+  [id (name direction) started_at finished_at])
+
+(def ^:private ^:sql insert-log-statement
+  "INSERT INTO %s (id, direction, started_at, finished_at)
+   VALUES (?, ?, ?, ?)")
+
+(def ^:private ^:sql select-log-statement
+  "SELECT * FROM %s
+   ORDER BY started_at ASC")
+
+(def ?Props
+  [:map
+   [:ds :any]
+   [:table-name :string]
+   [:lock-timeout-ms {:optional true} :int]
+   [:refresh-ms {:optional true} :int]])
+
+(defn create-datastore
+  {:malli/schema [:-> ?Props mallard.store/?DataStore]}
+  [{:keys [ds table-name]}]
+  (let [log-table (str (or table-name "mallard_migrations") "_log")
+        lock-sess-conn (atom nil)]
+
+    (jdbc/execute! ds [(format log-table-schema log-table)])
+
+    (reify mallard.store/DataStore
+      (load-state [_]
+        (let [entries
+              (into []
+                    (map row->entry)
+                    (jdbc/plan ds
+                               [(format select-log-statement log-table)]
+                               {:builder-fn rs/as-unqualified-lower-maps}))]
+          {:log entries}))
+
+      (save-state! [_ state]
+        (when-not (m/validate mallard.store/?State state)
+          (throw (ex-info "State schema validation failed"
+                          {:errors (me/humanize
+                                    (m/explain mallard.store/?State state))})))
+
+        (let [statement (format insert-log-statement log-table)
+              rows (map entry->row (:log state))]
+          (jdbc/with-transaction [tx ds]
+            (jdbc/execute! tx [(str "DELETE FROM " log-table)])
+            (jdbc/execute-batch! tx statement rows {}))))
+
+      (acquire-lock! [_]
+        (let [conn (reset! lock-sess-conn (jdbc/get-connection ds))
+              acquired? (-> (jdbc/execute-one!
+                             conn
+                             [(format
+                               "select pg_try_advisory_lock(%d) as lock_acquired"
+                               LOCK_ID)]
+                             {:return-keys true})
+                            :lock_acquired)]
+          (if acquired?
+            LOCK_ID
+            (throw (ex-info "Failed to acquire migration lock"
+                            {:lock-id LOCK_ID})))))
+
+      (release-lock! [_ _]
+        (when-let [conn @lock-sess-conn]
+          (jdbc/execute! conn [(format "SELECT pg_advisory_unlock(%d)" LOCK_ID)])
+          (.close conn)
+          (reset! lock-sess-conn nil))))))
+

--- a/packages/postgres/test/k16/mallard/pg_test.clj
+++ b/packages/postgres/test/k16/mallard/pg_test.clj
@@ -1,0 +1,58 @@
+(ns k16.mallard.pg-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [hikari-cp.core :as cp]
+   [k16.mallard.store :as mallard.store]
+   [k16.mallard.store.postgres :as store.pg]
+   [k16.mallard.test.pg :as test.pg]
+   [matcher-combinators.test]
+   [tick.core :as t]))
+
+(def ^:dynamic *pg* nil)
+
+(defn with-pg [test]
+  (test.pg/create-database-if-not-exists!)
+  (binding [*pg* (test.pg/create-test-ds!)]
+    (try
+      (test)
+      (finally
+        (cp/close-datasource *pg*)
+        (test.pg/drop-database!)))))
+
+(use-fixtures :each with-pg)
+
+(deftest pg-datastore-state-test
+  (testing "PG store state read/write operations"
+    (let [store (store.pg/create-datastore {:ds *pg*})
+          op {:id "1"
+              :direction :up
+              :started_at (t/now)
+              :finished_at (t/now)}]
+
+      (is (empty? (:log (mallard.store/load-state store))))
+      (mallard.store/save-state! store {:log [op]})
+
+      (let [state (mallard.store/load-state store)]
+        (is (= 1 (count (:log state))))
+        (is (match? (dissoc op :started_at :finished_at) (-> state :log first))))
+
+      (mallard.store/save-state! store {:log [op (assoc op :id "2")]})
+
+      (let [state (mallard.store/load-state store)]
+        (is (= 2 (count (:log state))))
+        (is (match? (dissoc op :started_at :finished_at) (-> state :log first)))
+        (is (match? (-> op (assoc :id "2") (dissoc :started_at :finished_at))
+                    (-> state :log second)))))))
+
+(deftest pg-datastore-lock-test
+  (testing "Should not allow more than one simultaneous lock"
+    (let [store (store.pg/create-datastore {:ds *pg*})
+          store2 (store.pg/create-datastore {:ds *pg*})]
+      (testing "Aquiring lock"
+        (let [lock (mallard.store/acquire-lock! store)]
+          (is (boolean lock))
+          (is (not (try (mallard.store/acquire-lock! store2)
+                        true
+                        (catch Exception _ false))))
+          (mallard.store/release-lock! store lock)
+          (is (boolean (mallard.store/acquire-lock! store2))))))))

--- a/packages/postgres/test/k16/mallard/test/pg.clj
+++ b/packages/postgres/test/k16/mallard/test/pg.clj
@@ -1,0 +1,81 @@
+(ns k16.mallard.test.pg
+  (:require
+   [hikari-cp.core :as cp]
+   [next.jdbc :as jdbc]))
+
+(defonce DB_NAME "mallard_pg_test")
+
+(defn database-exists?
+  "Checks if a database exists.
+   Args:
+     ds-config: Datasource config (connected to an existing database)
+   Returns:
+     true if exists, false otherwise"
+  [ds-config]
+  (let [ds (jdbc/get-datasource ds-config)]
+    (-> (jdbc/execute-one!
+         ds
+         [(format "SELECT 1 FROM pg_database WHERE datname = '%s'" DB_NAME)]
+         {:return-keys true})
+        boolean)))
+
+(defn create-database!
+  "Creates a new PostgreSQL database.
+   Args:
+     ds-config: Datasource config map (host, port, user, password, dbname)
+   Returns:
+     true if successful, throws on failure"
+  [ds-config]
+  (let [ds (jdbc/get-datasource ds-config)]
+    (try
+      (jdbc/execute! ds [(format "CREATE DATABASE %s" DB_NAME)] {:timeout 5000})
+      true
+      (catch Exception e
+        (throw e)))))
+
+(def base-ds-config
+  {:dbtype "postgresql"
+   :host "localhost"
+   :port 5432
+   :dbname "postgres"
+   :user "postgres"
+   :password "postgres"})
+
+(defn create-database-if-not-exists!
+  "Creates a database if it doesn't exist.
+   Returns:
+     true if created or already exists, throws on other errors"
+  []
+  (if (database-exists? base-ds-config)
+    true
+    (create-database! base-ds-config)))
+
+(def test-ds-config {:auto-commit true
+                     :read-only false
+                     :connection-timeout 30000
+                     :validation-timeout 5000
+                     :idle-timeout 600000
+                     :max-lifetime 1800000
+                     :minimum-idle 10
+                     :maximum-pool-size 10
+                     :pool-name "db-pool"
+                     :adapter "postgresql"
+                     :username "postgres"
+                     :password "postgres"
+                     :database-name DB_NAME
+                     :server-name "localhost"
+                     :port-number 5432
+                     :register-mbeans false})
+
+(defn create-test-ds! []
+  (cp/make-datasource test-ds-config))
+
+(defn drop-database! []
+  (let [ds (jdbc/get-datasource base-ds-config)]
+    (try
+      (jdbc/execute! ds [(format "DROP DATABASE %s" DB_NAME)] {:timeout 5000})
+      true
+      (catch Exception e
+        (throw e)))))
+
+


### PR DESCRIPTION
Adds postgres adapter, uses PG bultin advisory locks (db global). Lock must be acquired and released within same connection, migrations could use own connections. 