### PR TITLE
Allow setting metadata on operations

### DIFF
--- a/packages/mallard/src/k16/mallard/executor.clj
+++ b/packages/mallard/src/k16/mallard/executor.clj
@@ -11,6 +11,7 @@
 (def ?Operation
   [:map
    [:id :string]
+   [:metadata {:optional true} :map]
    [:run-up! {:error/message "should be a function with one argument"
               :optional true}
     [:=> [:cat :any] :any]]

--- a/packages/mallard/src/k16/mallard/loader/fs.clj
+++ b/packages/mallard/src/k16/mallard/loader/fs.clj
@@ -41,5 +41,6 @@
        (->> namespaces#
             (map (fn [namespace#]
                    {:id (-> namespace# (str/split #"\.") last)
+                    :metadata (meta (the-ns (symbol namespace#)))
                     :run-up! (resolve (symbol (str namespace# "/run-up!")))
                     :run-down! (resolve (symbol (str namespace# "/run-down!")))}))))))

--- a/packages/mallard/src/k16/mallard/loader/ns.clj
+++ b/packages/mallard/src/k16/mallard/loader/ns.clj
@@ -14,5 +14,6 @@
      (->> ~namespaces
           (map (fn [namespace#]
                  {:id (-> namespace# str (str/split #"\.") last)
+                  :metadata (meta (the-ns namespace#))
                   :run-up! (resolve (symbol (str namespace# "/run-up!")))
                   :run-down! (resolve (symbol (str namespace# "/run-down!")))})))))

--- a/packages/mallard/test/fixtures/migrations/1_migration.clj
+++ b/packages/mallard/test/fixtures/migrations/1_migration.clj
@@ -1,4 +1,5 @@
-(ns fixtures.migrations.1-migration)
+(ns fixtures.migrations.1-migration
+  {:some "metadata"})
 
 (defn run-up! [_])
 (defn run-down! [_])

--- a/packages/mallard/test/k16/mallard/loader/fs_test.clj
+++ b/packages/mallard/test/k16/mallard/loader/fs_test.clj
@@ -8,6 +8,7 @@
   (testing "It should load migrations from disk in the correct order"
     (let [migrations (loader.fs/load! "fixtures/migrations")]
       (is (match? [{:id "1-migration"
+                    :metadata {:some "metadata"}
                     :run-up! (requiring-resolve 'fixtures.migrations.1-migration/run-up!)
                     :run-down! (requiring-resolve 'fixtures.migrations.1-migration/run-down!)}
                    {:id "2-migration"

--- a/packages/mallard/test/k16/mallard/loader/ns_test.clj
+++ b/packages/mallard/test/k16/mallard/loader/ns_test.clj
@@ -9,6 +9,7 @@
     (let [migrations (loader.ns/load! '(fixtures.migrations.1-migration
                                         fixtures.migrations.2-migration))]
       (is (match? [{:id "1-migration"
+                    :metadata {:some "metadata"}
                     :run-up! (requiring-resolve 'fixtures.migrations.1-migration/run-up!)
                     :run-down! (requiring-resolve 'fixtures.migrations.1-migration/run-down!)}
                    {:id "2-migration"


### PR DESCRIPTION
Allow setting metadata on operations which can be used to do things like operation filtering during tests.

The ns and fs loaders populate this metadata map from the namespace metadata when loading operation namespaces.